### PR TITLE
Don't verify executables inside `icons` and `_data`

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -100,24 +100,6 @@ jobs:
           jobSummary: true
           format: markdown
           token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Verify file permissions
-        run: |
-          CHECK_DIRS="icons/ _data/"
-          echo "Searching the following directories for executable files:"
-          echo "${CHECK_DIRS}"
-          echo ""
-          EXE_FILES=$(find ${CHECK_DIRS} -type f -executable)
-          if test -n "${EXE_FILES-}"
-          then
-            echo "Some files were detected to have their executable bit set."
-            echo "To fix this, you can use 'chmod -x PATH/TO/FILE' on the following files:"
-            echo ""
-            echo "${EXE_FILES}"
-            exit 1
-          else
-            echo "All clear."
-            exit 0
-          fi
   test:
     name: Test package
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is uneeded because even if someone introduces an executable inside *icons/* or *_data/* repositories, needs to execute it to attack the repository modifing a file inside *.github/workflows/*, which would cause that GitHub won't run the job.

Also, there is no point in checking only some directories and not others.