### PR TITLE
Make popularity requirements for crates.io easier to understand

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,7 +97,7 @@ To be considered popular enough to be within our scope, a brand must be in exist
 1. Its packages meet one of the following minimum requirements:
    - [npm](https://www.npmjs.com): 100k weekly downloads,
    - [jsDelivr](https://www.jsdelivr.com): 1m daily or 35m monthly requests,
-   - [crates.io](https://crates.io): 100k weekly downloads,
+   - [crates.io](https://crates.io): 1,200,000 recent (100k weekly) downloads,
    - [PyPi Stats](https://pypistats.org): 100k weekly downloads,
    - [Homebrew Formulae](https://formulae.brew.sh): 5k installs in the last 30 days or 50k installs in the last year,
    - [Arch User Repository](https://aur.archlinux.org): popularity of 7.00 or,


### PR DESCRIPTION
Currently, in https://crates.io there is no a proper way to check the weekly downloads of a crate. The main two stats are "all-time" and "recent"  downloads:

![image](https://github.com/user-attachments/assets/129c5067-279b-463f-949c-40f691d0d2c9)

The "Recent" container counts downloads in the past 3 months. So weekly downloads means 1'2m downloads or 1,200,000 as is displayed in crates.io UI. Updated reflecting that as is easier to understand.

BTW, currently there are 1749 crates that meet our crates.io popularity metrics.